### PR TITLE
Remove nondeletable

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -24,7 +24,6 @@
       "home automation"
     ],
     "enabled": false,
-    "nondeletable": true,
     "type": "hardware"
   },
   "native": {


### PR DESCRIPTION
common.nondeletable - (optional) [true/false] this adapter cannot be deleted or updated. It will be updated together with controller.